### PR TITLE
Bugs fix : Commands can't be executed because apiSecret is loaded incorrectly

### DIFF
--- a/__test__/lib/services/extendUserDataSteam.test.js
+++ b/__test__/lib/services/extendUserDataSteam.test.js
@@ -4,7 +4,7 @@ import extendUserDataStream from '../../../src/lib/services/extendUserDataStream
 describe('extendUserDataStream', () => {
 
   const apiKey = 'xxxx';
-  const apiSecet = 'yyyyy';
+  const apiSecret = 'yyyyy';
   const resp = {};
 
   beforeEach(() => {
@@ -12,6 +12,6 @@ describe('extendUserDataStream', () => {
   });
 
   it('should extend the data stream', async () => {
-    await expect(extendUserDataStream(apiKey, apiSecet)('xxxxx')).resolves.toBeDefined();
+    await expect(extendUserDataStream(apiKey, apiSecret)('xxxxx')).resolves.toBeDefined();
   });
 });

--- a/__test__/lib/services/getUserDataSteam.test.js
+++ b/__test__/lib/services/getUserDataSteam.test.js
@@ -4,7 +4,7 @@ import getUserDataStream from '../../../src/lib/services/getUserDataStream';
 describe('getUserDataStream', () => {
 
   const apiKey = 'xxxx';
-  const apiSecet = 'yyyyy';
+  const apiSecret = 'yyyyy';
   const resp = { data: { listenKey: 'xxxxxxxx' } };
 
   beforeEach(() => {
@@ -12,6 +12,6 @@ describe('getUserDataStream', () => {
   });
 
   it('should returun return listen key', async () => {
-    await expect(getUserDataStream(apiKey, apiSecet)).resolves.toEqual('xxxxxxxx');
+    await expect(getUserDataStream(apiKey, apiSecret)).resolves.toEqual('xxxxxxxx');
   });
 });

--- a/src/delivery-futures-user.js
+++ b/src/delivery-futures-user.js
@@ -5,12 +5,12 @@ import SocketClient from './lib/socketClient';
 import logger from './lib/logger';
 
 const APIKEY = process.env.APIKEY || '';
-const APISECET = process.env.APISECET || '';
+const APISECRET = process.env.APISECRET || '';
 const WS_BASEURL = process.env.WS_BASEURL || 'wss://dstream.binance.com/';
 
 export default async function createApp() {
   logger.info('start application');
-  const listenKey = await getDeliveryListenKey(APIKEY, APISECET, false);
+  const listenKey = await getDeliveryListenKey(APIKEY, APISECRET, false);
 
   logger.info('key received.', listenKey);
   const socketApi = new SocketClient(`ws/${listenKey}`, WS_BASEURL);

--- a/src/futures-user.js
+++ b/src/futures-user.js
@@ -6,13 +6,13 @@ import SocketClient from './lib/socketClient';
 import logger from './lib/logger';
 
 const APIKEY = process.env.APIKEY || '';
-const APISECET = process.env.APISECET || '';
+const APISECRET = process.env.APISECRET || '';
 const WSS_BASE_URL = process.env.WSS_BASE_URL || 'wss://fstream.binance.com/';
 const HTTP_BASE_URL = process.env.HTTP_BASE_URL || 'https://fapi.binance.com/';
 
 export default async function createApp() {
   logger.info('start application');
-  const listenKey = await getListenKey(APIKEY, APISECET, HTTP_BASE_URL);
+  const listenKey = await getListenKey(APIKEY, APISECRET, HTTP_BASE_URL);
 
   logger.info('key received.', listenKey);
   const socketApi = new SocketClient(`ws/${listenKey}`, WSS_BASE_URL);
@@ -21,7 +21,7 @@ export default async function createApp() {
 
   // renew listenkey
   setInterval(() => {
-    extendUserDataStream(APIKEY, APISECET, HTTP_BASE_URL)
+    extendUserDataStream(APIKEY, APISECRET, HTTP_BASE_URL)
       .then(logger.info('ListenKey is renewed'));
   }, 1000 * 60 * 45); // review the key every 45 mins
 }

--- a/src/lib/requestClient.js
+++ b/src/lib/requestClient.js
@@ -24,8 +24,12 @@ const privateRequest = (apiKey, apiSecret, baseURL) => (
   path,
   data = {},
 ) => {
-  if (!apiKey || !apiSecret) {
+  if (!apiKey) {
     throw new Error('API key is missing');
+  }
+
+  if (!apiSecret) {
+    throw new Error('API secret is missing');
   }
 
   const timestamp = Date.now();

--- a/src/margin-user.js
+++ b/src/margin-user.js
@@ -6,18 +6,18 @@ import renewListenKey from './lib/helpers/renewListenKey';
 import logger from './lib/logger';
 
 const { APIKEY } = process.env;
-const { APISECET } = process.env;
+const { APISECRET } = process.env;
 
 export default async function createApp() {
   logger.info('start application to get margin user account update');
-  const listenKey = await getUserDataStream(APIKEY, APISECET);
+  const listenKey = await getUserDataStream(APIKEY, APISECRET);
 
   logger.info('key received.');
   const socketApi = new SocketClient(`ws/${listenKey}`);
   socketApi.setHandler('executionReport', (params) => logger.info(params));
   socketApi.setHandler('outboundAccountInfo', (params) => logger.info(params));
 
-  renewListenKey(APIKEY, APISECET)(listenKey);
+  renewListenKey(APIKEY, APISECRET)(listenKey);
 }
 
 createApp();


### PR DESCRIPTION
The project contains multiple typos that cause confusions to other developers:

In README.md the document specifies that an environemnt variable 'APISECRET' needs to be passed in.

However the code actually reads the variable 'APISECET' (without R) which is a typo.
The consequence is that we cannot run the commands specified within the documentation.

Moreover the error is misleading. Once the apiSecret is not found, the exception 'API key is missing' is thrown.
'API secret is missing' should be thrown instead.

Fixes:
 - Rename all mispelled variables to the correct ones.
 - Add the correct error when the the api secret is missing.